### PR TITLE
Restructure labels -> targets in metamodel

### DIFF
--- a/src/ontology/MetaModel.json
+++ b/src/ontology/MetaModel.json
@@ -2,17 +2,10 @@
   "type": "pt",
   "classifiers": [
     {
-      "type": "place",
-      "labels": [
-        "name",
-        "marking"
-      ]
+      "type": "place"
     },
     {
-      "type": "transition",
-      "labels": [
-        "name"
-      ]
+      "type": "transition"
     }
   ],
   "relations": [
@@ -26,10 +19,7 @@
           "place"
         ]
       },
-      "arrow-end": "arrow-head",
-      "labels": [
-        "name"
-      ]
+      "arrow-end": "arrow-head"
     }
   ],
   "arrow-heads": [
@@ -39,13 +29,20 @@
   ],
   "texts": [
     {
-      "type": "name"
+      "type": "name",
+      "targets": [
+        "place",
+        "transition",
+        "arc"
+      ]
     },
     {
       "type": "marking",
       "regex": "\\d+",
-      "default": "1"
+      "default": "1",
+      "targets": [
+        "place"
+      ]
     }
   ]
 }
-


### PR DESCRIPTION
Closes #5 

## Changes
- Changed syntax in metamodel, so that texts are defining its targets