### PR TITLE
Fix the position of places and transitions

### DIFF
--- a/src/parsers/PnmlParser.js
+++ b/src/parsers/PnmlParser.js
@@ -72,6 +72,8 @@ export default class PnmlParser {
         }
 
         if (elementData.graphics && elementData.graphics.dimension) {
+            element.x -= elementData.graphics.dimension.x / 2;
+            element.y -= elementData.graphics.dimension.y / 2;
             this.setDimension(element, elementData.graphics.dimension);
         }
 

--- a/src/serializers/PnmlSerializer.js
+++ b/src/serializers/PnmlSerializer.js
@@ -114,8 +114,8 @@ export default class PnmlSerializer {
 
         if (element.x && element.y) {
             const positionElement = doc.createElement('position');
-            positionElement.setAttribute('x', element.x);
-            positionElement.setAttribute('y', element.y);
+            positionElement.setAttribute('x', element.x + element.width / 2);
+            positionElement.setAttribute('y', element.y + element.height / 2);
             graphicsElement.appendChild(positionElement);
         }
 
@@ -138,6 +138,8 @@ export default class PnmlSerializer {
                 this.idMap[element.targetId]
             );
         }
+
+        console.log(element);
 
         return classifierElement;
     }

--- a/src/serializers/PnmlSerializer.js
+++ b/src/serializers/PnmlSerializer.js
@@ -112,7 +112,7 @@ export default class PnmlSerializer {
 
         const graphicsElement = doc.createElement('graphics');
 
-        if (element.x && element.y) {
+        if (element.hasOwnProperty('x') && element.hasOwnProperty('y')) {
             const positionElement = doc.createElement('position');
             positionElement.setAttribute('x', element.x + element.width / 2);
             positionElement.setAttribute('y', element.y + element.height / 2);


### PR DESCRIPTION
Closes #18 
Relates to renew-js/renew-lib#146

## Changes
- As the [PNML specification][0] shows, that the position of the elements are at the center of the object, I've added the offset to the specific elements. 

![grafik](https://user-images.githubusercontent.com/5788010/61182113-3981ea80-a62f-11e9-9d53-5365ce397c0d.png)

![grafik](https://user-images.githubusercontent.com/5788010/61182141-97163700-a62f-11e9-8d64-4634797cf94e.png)
![grafik](https://user-images.githubusercontent.com/5788010/61182148-aac19d80-a62f-11e9-91e4-5a2097c66e45.png)


[0]: http://www.petrinets.info/docs/ISO-IEC15909-2.WD.V0.9.0.pdf